### PR TITLE
Select the best pixel format for use with the screen

### DIFF
--- a/src/auxiliary.c
+++ b/src/auxiliary.c
@@ -193,10 +193,3 @@ void color_lookup(int col, uint8_t* r, uint8_t* g, uint8_t* b)
             break;
     }
 }
-
-uint32_t lookup_color(int col)
-{
-    uint8_t r, g, b;
-    color_lookup(col, &r, &g, &b);
-    return (r << 24) | (g << 16) | (b << 8) | 0xFF;
-}

--- a/src/auxiliary.h
+++ b/src/auxiliary.h
@@ -13,6 +13,5 @@
 #include <stdint.h>
 
 void color_lookup(int col, uint8_t* r, uint8_t* g, uint8_t* b);
-uint32_t lookup_color(int col);
 
 #endif // AUXILIARY_H


### PR DESCRIPTION
This avoids needing to convert between true colour formats on every frame for renderers that don't support `SDL_PIXELFORMAT_RGBA8888`.