### PR TITLE
Update SDL3 to version 3.2.12

### DIFF
--- a/.github/workflows/n3ds.yml
+++ b/.github/workflows/n3ds.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           repository: libsdl-org/SDL
           path: .github/SDL
-          ref: 0306b5a865b7e7e8ff52f107c00c002cdddaae02
+          ref: release-3.2.12
       - name: Install SDL3
         run: |
           cmake -S .github/SDL -B .github/SDL-build -DCMAKE_TOOLCHAIN_FILE=$DEVKITPRO/cmake/3DS.cmake \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ else()
   set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${EXPORT_DIR})
 
   include(get_SDL3)
-  get_SDL3("3.2.8")
+  get_SDL3("3.2.12")
 
   set(z8lua_sources
     ${CMAKE_CURRENT_SOURCE_DIR}/src/z8lua/lapi.c

--- a/cmake/get_SDL3.cmake
+++ b/cmake/get_SDL3.cmake
@@ -8,13 +8,13 @@ macro(get_SDL3 version)
       SDL3
       URL https://github.com/libsdl-org/SDL/releases/download/release-${version}/SDL3-devel-${version}-VC.zip
       URL_HASH
-        SHA256=a674c6a6c7ece82227ceeb879c35fd4716e351752ff8b030f8629d832d028fa7)
+        SHA256=dd7415a5245ac6cd7f6e08cd6261eebe35c48cfc67ac8c580139c36fd9945344)
   elseif(MINGW)
     FetchContent_Declare(
       SDL3
       URL https://github.com/libsdl-org/SDL/releases/download/release-${version}/SDL3-devel-${version}-mingw.zip
       URL_HASH
-        SHA256=557661694a37bf3f9c4076353bebe7c0e5d457077f093d4e52c756a83706ba24)
+        SHA256=34e6eb4b964e612fb36ab58295a00e77ef625d5d5cc88f99317cd0d12a3df415)
   else()
     find_package(SDL3 QUIET)
     if(NOT SDL3_FOUND)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${EXPORT_DIR}")
 set(CMAKE_C_STANDARD 99)
 
 include(get_SDL3)
-get_SDL3("3.2.8")
+get_SDL3("3.2.12")
 
 set(PICO_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../src")
 


### PR DESCRIPTION
This fixes launching the application on the 3DS. There is still a crash in the api.p8 demo, but that can also be reproduced with Address Sanitizer on desktop platforms.