### PR TITLE
Restore support for running in windowed mode

### DIFF
--- a/src/app.c
+++ b/src/app.c
@@ -12,58 +12,6 @@
 #include "app.h"
 
 static SDL_AudioDeviceID audio_device;
-static int scale;
-static int window_w;
-static int window_h;
-static int window_offset_x;
-static int window_offset_y;
-
-int get_scale(void)
-{
-#ifdef __SYMBIAN32__
-	return 1;
-#else
-	return scale;
-#endif
-}
-
-void get_window_offset(int* x, int* y)
-{
-#ifdef __SYMBIAN32__
-	if (x) {
-		*x = 8;
-	}
-	if (y) {
-		*y = 1;
-	}
-#else
-	if (x) {
-		*x = window_offset_x;
-	}
-	if (y) {
-		*y = window_offset_y;
-	}
-#endif
-}
-
-void get_window_size(int* w, int* h)
-{
-#ifdef __SYMBIAN32__
-	if (w) {
-		*w = 176;
-	}
-	if (h) {
-		*h = 208;
-	}
-#else
-	if (w) {
-		*w = window_w;
-	}
-	if (h) {
-		*h = window_h;
-	}
-#endif
-}
 
 bool init_app(SDL_Renderer** renderer, SDL_Window* window)
 {
@@ -83,37 +31,7 @@ bool init_app(SDL_Renderer** renderer, SDL_Window* window)
 		SDL_Log("Couldn't initialize gamepad subsystem: %s", SDL_GetError());
 	}
 
-	SDL_DisplayID display = SDL_GetPrimaryDisplay();
-	const SDL_DisplayMode* mode = SDL_GetDesktopDisplayMode(display);
-	if (!mode)
-	{
-		SDL_Log("Could not get desktop display mode: %s", SDL_GetError());
-		return false;
-	}
-
-	int native_w = mode->w;
-	int native_h = mode->h;
-
-	int base_w = 128;
-	int base_h = 128;
-
-	int scale_x = native_w / base_w;
-	int scale_y = native_h / base_h;
-
-	scale = (scale_x < scale_y) ? scale_x : scale_y;
-	scale = scale - 1; // Leave some room for the window border and title bar.
-	if (scale < 1)
-	{
-		scale = 1;
-	}
-
-	window_w = base_w * scale;
-	window_h = base_h * scale;
-
-	window_offset_x = (mode->w - window_w) / 2;
-	window_offset_y = (mode->h - window_h) / 2;
-
-	window = SDL_CreateWindow("open8", mode->w, mode->h, SDL_WINDOW_FULLSCREEN);
+	window = SDL_CreateWindow("open8", 160 * 2, 205 * 2, SDL_WINDOW_HIGH_PIXEL_DENSITY);
 	if (!window)
 	{
 		SDL_Log("Couldn't create window: %s", SDL_GetError());
@@ -127,6 +45,34 @@ bool init_app(SDL_Renderer** renderer, SDL_Window* window)
 		SDL_Log("Couldn't create window/renderer: %s", SDL_GetError());
 		return false;
 	}
+
+	int native_w, native_h;
+	SDL_GetRenderOutputSize(*renderer, &native_w, &native_h);
+
+	int base_w = 160;
+	int base_h = 205;
+
+	int scale_x = native_w / base_w;
+	int scale_y = native_h / base_h;
+
+	int scale = (scale_x < scale_y) ? scale_x : scale_y;
+	if (scale < 1)
+	{
+		scale = 1;
+	}
+
+	int window_w = base_w * scale;
+	int window_h = base_h * scale;
+
+	cart_rect.x = (native_w - window_w) / 2;
+	cart_rect.y = (native_h - window_h) / 2;
+	cart_rect.w = window_w;
+	cart_rect.h = window_h;
+
+	screen_rect.x = cart_rect.x + (scale * 16);
+	screen_rect.y = cart_rect.y + (scale * 24);
+	screen_rect.w = (scale * 128);
+	screen_rect.h = (scale * 128);
 
 	SDL_AudioSpec spec;
 	spec.channels = 1;

--- a/src/app.h
+++ b/src/app.h
@@ -12,9 +12,7 @@
 
 #include <SDL3/SDL.h>
 
-int get_scale(void);
-void get_window_offset(int* x, int* y);
-void get_window_size(int* w, int* h);
+extern SDL_FRect cart_rect, screen_rect;
 
 bool init_app(SDL_Renderer** renderer, SDL_Window* window);
 void destroy_app(void);

--- a/src/core.c
+++ b/src/core.c
@@ -45,6 +45,8 @@ static bool has_update;
 static bool has_update60;
 static bool has_draw;
 
+SDL_FRect cart_rect;
+
 static void* mem_allocator(void* ud, void* ptr, size_t osize, size_t nsize)
 {
 	(void)ud;
@@ -594,37 +596,9 @@ static void select_prev_cartridge(SDL_Renderer* renderer)
 
 static void render_cartridge(SDL_Renderer* renderer)
 {
-	SDL_SetRenderTarget(renderer, NULL);
-
-	SDL_FRect dest;
-	SDL_FRect source;
-
-#ifdef __SYMBIAN32__
-	source.x = 0.f;
-	source.y = 0.f;
-	source.w = 160.f;
-	source.h = 205.f;
-#else
-	source.x = 16.f;
-	source.y = 24.f;
-	source.w = 128.f;
-	source.h = 128.f;
-#endif
-
-	int window_w, window_h;
-	get_window_size(&window_w, &window_h);
-
-	int offset_x, offset_y;
-	get_window_offset(&offset_x, &offset_y);
-
-	dest.x = (float)offset_x;
-	dest.y = (float)offset_y;
-	dest.w = (float)window_w;
-	dest.h = (float)window_h;
-
-	SDL_SetRenderDrawColor(renderer, 0x31, 0x31, 0x31, 0xff);
+	SDL_SetRenderDrawColor(renderer, 0x64, 0x64, 0x64, 0xff);
 	SDL_RenderClear(renderer);
-	SDL_RenderTexture(renderer, cart.image, &source, &dest);
+	SDL_RenderTexture(renderer, cart.image, NULL, &cart_rect);
 }
 
 bool init_core(SDL_Renderer* renderer)
@@ -856,6 +830,7 @@ bool iterate_core(SDL_Renderer* renderer)
 		}
 
 		update_time();
+		render_cartridge(renderer);
 		update_from_virtual_memory(renderer);
 		SDL_RenderPresent(renderer);
 

--- a/src/memory.c
+++ b/src/memory.c
@@ -25,6 +25,8 @@ static uint32_t expanded_map[256];
 static SDL_Texture* screen;
 static SDL_PixelFormat screen_format;
 
+SDL_FRect screen_rect;
+
 bool init_memory(SDL_Renderer* renderer)
 {
     if (!renderer)
@@ -255,31 +257,7 @@ void update_from_virtual_memory(SDL_Renderer* renderer)
         SDL_UnlockTexture(screen);
     }
 
-    SDL_FRect dest;
-
-#ifdef __SYMBIAN32__
-    dest.x = 24.f;
-    dest.y = 25.f;
-    dest.w = 128.f;
-	dest.h = 128.f;
-
-    SDL_RenderTexture(renderer, screen, NULL, &dest);
-
-#else
-
-    int window_w, window_h;
-    get_window_size(&window_w, &window_h);
-
-    int offset_x, offset_y;
-    get_window_offset(&offset_x, &offset_y);
-
-    dest.x = (float)offset_x;
-    dest.y = (float)offset_y;
-    dest.w = (float)window_w;
-    dest.h = (float)window_h;
-
-    SDL_RenderTexture(renderer, screen, NULL, &dest);
-#endif
+    SDL_RenderTexture(renderer, screen, NULL, &screen_rect);
 }
 
 uint32_t crc32(const uint8_t* data, size_t start, size_t length)


### PR DESCRIPTION
On platforms that only support full screen mode, the full screen flag will be applied automatically and the window size will be set to the full screen dimensions rather than the ones provided to `SDL_CreateWindow`.